### PR TITLE
fix: update logic to allow var. vpc_name to be null

### DIFF
--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -24,5 +24,4 @@ module "slz_vpc" {
   region            = var.region
   prefix            = var.prefix
   tags              = var.resource_tags
-  vpc_name          = var.prefix
 }

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@
 ##############################################################################
 
 resource "ibm_is_vpc" "vpc" {
-  name                        = var.prefix != null ? "${var.prefix}-${var.vpc_name}" : var.vpc_name
+  name                        = var.vpc_name != null ? "${var.prefix}-${var.vpc_name}" : "${var.prefix}-vpc"
   resource_group              = var.resource_group_id
   classic_access              = var.classic_access
   address_prefix_management   = var.use_manual_address_prefixes == false ? null : "manual"


### PR DESCRIPTION
### Description

update logic to allow var. vpc_name to be null. Currently if it is left null, the module fails with:
```
│Error: Invalid template interpolation value
│
│  on ../../main.tf line 6, in resource "ibm_is_vpc" "vpc":
│   6:   name                        = var.prefix != null ? "${var.prefix}-${var.vpc_name}" : var.vpc_name
│├────────────────
││var.vpc_name is null
```

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
