### PR TITLE
feat: subnet output created to be consumed by terraform-base-ocp-vpc module

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You need the following permissions to run this module.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_cluster_subnets"></a> [cluster\_subnets](#output\_cluster\_subnets) | Map to be consumed by vpc cluster containing id, CIDR blocks, and zones. |
 | <a name="output_network_acls"></a> [network\_acls](#output\_network\_acls) | List of shortnames and IDs of network ACLs |
 | <a name="output_public_gateways"></a> [public\_gateways](#output\_public\_gateways) | Map of public gateways by zone |
 | <a name="output_subnet_detail_list"></a> [subnet\_detail\_list](#output\_subnet\_detail\_list) | A list of subnets containing names, CIDR blocks, and zones. |

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -395,12 +395,20 @@
     }
   },
   "outputs": {
+    "cluster_subnets": {
+      "name": "cluster_subnets",
+      "description": "Map to be consumed by vpc cluster containing id, CIDR blocks, and zones.",
+      "pos": {
+        "filename": "outputs.tf",
+        "line": 82
+      }
+    },
     "network_acls": {
       "name": "network_acls",
       "description": "List of shortnames and IDs of network ACLs",
       "pos": {
         "filename": "outputs.tf",
-        "line": 87
+        "line": 103
       }
     },
     "public_gateways": {
@@ -451,7 +459,7 @@
       "description": "Details of VPC flow logs collector",
       "pos": {
         "filename": "outputs.tf",
-        "line": 104
+        "line": 120
       }
     },
     "vpc_id": {

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -400,7 +400,7 @@
       "description": "Map to be consumed by vpc cluster containing id, CIDR blocks, and zones.",
       "pos": {
         "filename": "outputs.tf",
-        "line": 82
+        "line": 81
       }
     },
     "network_acls": {
@@ -408,7 +408,7 @@
       "description": "List of shortnames and IDs of network ACLs",
       "pos": {
         "filename": "outputs.tf",
-        "line": 103
+        "line": 91
       }
     },
     "public_gateways": {
@@ -459,7 +459,7 @@
       "description": "Details of VPC flow logs collector",
       "pos": {
         "filename": "outputs.tf",
-        "line": 120
+        "line": 108
       }
     },
     "vpc_id": {

--- a/outputs.tf
+++ b/outputs.tf
@@ -80,7 +80,7 @@ output "subnet_zone_list" {
 
 output "cluster_subnets" {
   description = "Map to be consumed by vpc cluster containing id, CIDR blocks, and zones."
-  value = zipmap([for prefix ,_ in var.address_prefixes: prefix ], [for subnet in ibm_is_subnet.subnet: [{id=subnet.id,zone=subnet.zone,cidr_block=subnet.ipv4_cidr_block}]])
+  value       = zipmap([for prefix, _ in var.address_prefixes : prefix], [for subnet in ibm_is_subnet.subnet : [{ id = subnet.id, zone = subnet.zone, cidr_block = subnet.ipv4_cidr_block }]])
 }
 ##############################################################################
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,22 +78,10 @@ output "subnet_zone_list" {
   ]
 }
 
-
 output "cluster_subnets" {
   description = "Map to be consumed by vpc cluster containing id, CIDR blocks, and zones."
-
-  value = {
-    for zone_name in distinct([for subnet in ibm_is_subnet.subnet : subnet.zone]) : zone_name => [{
-      for subnet in ibm_is_subnet.subnet : subnet.name =>
-      {
-        id   = subnet.id
-        zone = subnet.zone
-        cidr = subnet.ipv4_cidr_block
-      }
-    }]
-  }
+  value = zipmap([for prefix ,_ in var.address_prefixes: prefix ], [for subnet in ibm_is_subnet.subnet: [{id=subnet.id,zone=subnet.zone,cidr_block=subnet.ipv4_cidr_block}]])
 }
-
 ##############################################################################
 
 ##############################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -78,6 +78,22 @@ output "subnet_zone_list" {
   ]
 }
 
+
+output "cluster_subnets" {
+  description = "Map to be consumed by vpc cluster containing id, CIDR blocks, and zones."
+
+  value = {
+    for zone_name in distinct([for subnet in ibm_is_subnet.subnet : subnet.zone]) : zone_name => [{
+      for subnet in ibm_is_subnet.subnet : subnet.name =>
+      {
+        id   = subnet.id
+        zone = subnet.zone
+        cidr = subnet.ipv4_cidr_block
+      }
+    }]
+  }
+}
+
 ##############################################################################
 
 ##############################################################################


### PR DESCRIPTION
### Description

This is to simplify the subnet output to be consumed by terraform-base-ocp-vpc module.
Refer [Issue 399](https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone-vpc/issues/399)
### Types of changes in this PR
New output value is added.
#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [x] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [x] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [x] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
