### PR TITLE
fix: replace zipmap in output.tf

### DIFF
--- a/module-metadata.json
+++ b/module-metadata.json
@@ -377,7 +377,7 @@
       "description": "List of shortnames and IDs of network ACLs",
       "pos": {
         "filename": "outputs.tf",
-        "line": 91
+        "line": 105
       }
     },
     "public_gateways": {
@@ -436,7 +436,7 @@
       "description": "Details of VPC flow logs collector",
       "pos": {
         "filename": "outputs.tf",
-        "line": 108
+        "line": 122
       }
     },
     "vpc_id": {

--- a/outputs.tf
+++ b/outputs.tf
@@ -80,8 +80,22 @@ output "subnet_zone_list" {
 
 output "subnet_detail_map" {
   description = "A map of subnets containing IDs, CIDR blocks, and zones"
-  value       = zipmap([for prefix, _ in var.address_prefixes : prefix], [for subnet in ibm_is_subnet.subnet : [{ id = subnet.id, zone = subnet.zone, cidr_block = subnet.ipv4_cidr_block }]])
+  value = {
+    for zone_name in distinct([
+      for subnet in ibm_is_subnet.subnet :
+      subnet.zone
+    ]) :
+    "zone-${substr(zone_name, -1, length(zone_name))}" => [
+      for subnet in ibm_is_subnet.subnet :
+      {
+        id         = subnet.id
+        zone       = subnet.zone
+        cidr_block = subnet.ipv4_cidr_block
+      } if subnet.zone == zone_name
+    ]
+  }
 }
+
 ##############################################################################
 
 ##############################################################################


### PR DESCRIPTION
### Description

When we had more than one subnet in one zone, the zipmap function used in the output.tf would give the following error
```Call to function "zipmap" failed: number of keys (3) does not match number of values (6).``` 

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
