### PR TITLE
fix: resolving duplicate outbound address names for acl rules

### DIFF
--- a/network_acls.tf
+++ b/network_acls.tf
@@ -63,7 +63,7 @@ locals {
   vpc_outbound_rule = [
     for address in data.ibm_is_vpc_address_prefixes.get_address_prefixes.address_prefixes :
     {
-      name        = "ibmflow-allow-vpc-connectivity-outbound-${substr(address.name, -4, -1)}"
+      name        = "ibmflow-allow-vpc-connectivity-outbound-${substr(address.id, -4, -1)}"
       action      = "allow"
       source      = var.network_cidr != null ? var.network_cidr : "0.0.0.0/0"
       destination = address.cidr


### PR DESCRIPTION
### Description

This is to fix the issue seen as duplicate names for acl rule. Refer [issue-4501](https://github.ibm.com/goldeneye/issues/issues/4501)

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

 - Resolved duplicate ACL rule name seen for outbound rules.
---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
