### PR TITLE
fix: extend the vpc output data

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ To attach access management tags to resources in this module, you need the follo
 | <a name="output_subnet_ids"></a> [subnet\_ids](#output\_subnet\_ids) | The IDs of the subnets |
 | <a name="output_subnet_zone_list"></a> [subnet\_zone\_list](#output\_subnet\_zone\_list) | A list containing subnet IDs and subnet zones |
 | <a name="output_vpc_crn"></a> [vpc\_crn](#output\_vpc\_crn) | CRN of VPC created |
+| <a name="output_vpc_data"></a> [vpc\_data](#output\_vpc\_data) | Data of the VPC created. |
 | <a name="output_vpc_flow_logs"></a> [vpc\_flow\_logs](#output\_vpc\_flow\_logs) | Details of VPC flow logs collector |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | ID of VPC created |
 | <a name="output_vpc_name"></a> [vpc\_name](#output\_vpc\_name) | Name of VPC created |

--- a/cra-tf-validate-ignore-rules.json
+++ b/cra-tf-validate-ignore-rules.json
@@ -11,6 +11,12 @@
             "description:": "Check whether Cloud Object Storage is enabled with customer-managed encryption and Keep Your Own Key (KYOK)",
             "ignore_reason": "This module does not create any Cloud object storage and it is used in an example for testing purpose.",
             "is_valid": false
+        },
+        {
+            "scc_rule_id": "rule-216e2449-27d7-4afc-929a-b66e196a9cf9",
+            "description": "Check whether Flow Logs for VPC are enabled",
+            "ignore_reason": "This rule should not be failing as we do enable flow logs in the code. Bug reported with CRA: https://github.ibm.com/oneibmcloud/CD-CRA/issues/1907",
+            "is_valid": false
         }
     ]
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -471,6 +471,7 @@
     "vpc_data": {
       "name": "vpc_data",
       "description": "Data of the VPC created.",
+      "value": "ibm_is_vpc.vpc",
       "pos": {
         "filename": "outputs.tf",
         "line": 145

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -468,6 +468,14 @@
       "type": "TypeString",
       "cloud_data_type": "crn"
     },
+    "vpc_data": {
+      "name": "vpc_data",
+      "description": "Data of the VPC created.",
+      "pos": {
+        "filename": "outputs.tf",
+        "line": 145
+      }
+    },
     "vpc_flow_logs": {
       "name": "vpc_flow_logs",
       "description": "Details of VPC flow logs collector",

--- a/outputs.tf
+++ b/outputs.tf
@@ -141,3 +141,14 @@ output "cidr_blocks" {
   description = "List of CIDR blocks present in VPC stack"
   value       = [for address in data.ibm_is_vpc_address_prefixes.get_address_prefixes.address_prefixes : address.cidr]
 }
+
+output "vpc_data" {
+  description = "Data of the VPC created."
+  value = {
+    crn                 = ibm_is_vpc.vpc.crn
+    id                  = ibm_is_vpc.vpc.id
+    name                = ibm_is_vpc.vpc.name
+    resource_group      = ibm_is_vpc.vpc.resource_group
+    resource_group_name = ibm_is_vpc.vpc.resource_group_name
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -144,11 +144,5 @@ output "cidr_blocks" {
 
 output "vpc_data" {
   description = "Data of the VPC created."
-  value = {
-    crn                 = ibm_is_vpc.vpc.crn
-    id                  = ibm_is_vpc.vpc.id
-    name                = ibm_is_vpc.vpc.name
-    resource_group      = ibm_is_vpc.vpc.resource_group
-    resource_group_name = ibm_is_vpc.vpc.resource_group_name
-  }
+  value       = ibm_is_vpc.vpc
 }


### PR DESCRIPTION
### Description

Need few extra information of vpc in the slz to create a output in SLZ. As per this [Issue](https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/issues/605)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Adding a detailed vpc output.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
