### PR TITLE
fix: change acl for_each conditional to fix bug

### DIFF
--- a/network_acls.tf
+++ b/network_acls.tf
@@ -160,7 +160,11 @@ locals {
 }
 
 resource "ibm_is_network_acl" "network_acl" {
-  for_each       = var.create_subnets ? local.acl_object : {}
+  # due to a bug in terraform ternary conditional and nested map objects, use a for loop with if condition to only apply
+  # ACLs if subnets are being created (not for existing subnets scenario)
+  # The old version of this that had the bug was:
+  # for_each       = var.create_subnets ? local.acl_object : {}
+  for_each       = { for acl_key, acl_value in local.acl_object : acl_key => acl_value if var.create_subnets }
   name           = var.prefix != null ? "${var.prefix}-${each.key}" : each.key #already has name of vpc in each.key
   vpc            = local.vpc_id
   resource_group = var.resource_group_id


### PR DESCRIPTION
### Description

Fix a Terraform bug with a conditional statement. Instead of ternary style we are switching to a "for loop with if condition" style for the ACL resource to avoid the bug.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
