### PR TITLE
test: add delay between hub and spoke in example

### DIFF
--- a/examples/hub-spoke-delegated-resolver/main.tf
+++ b/examples/hub-spoke-delegated-resolver/main.tf
@@ -12,10 +12,10 @@ module "resource_group" {
 
 #############################################################################
 # Delay between hub and spoke creation/destruction
-# 
+#
 # You can adjust these delay timings if needed.
 # This block will put a slight delay between the Hub and Spoke VPC operations.
-# This will help if there are resources (such as DNS resolver) that need some 
+# This will help if there are resources (such as DNS resolver) that need some
 # extra time to fully complete before the other VPC operations continue.
 #############################################################################
 resource "time_sleep" "delay_between_hub_spoke" {

--- a/examples/hub-spoke-delegated-resolver/main.tf
+++ b/examples/hub-spoke-delegated-resolver/main.tf
@@ -11,6 +11,20 @@ module "resource_group" {
 }
 
 #############################################################################
+# Delay between hub and spoke creation/destruction
+# 
+# You can adjust these delay timings if needed.
+# This block will put a slight delay between the Hub and Spoke VPC operations.
+# This will help if there are resources (such as DNS resolver) that need some 
+# extra time to fully complete before the other VPC operations continue.
+#############################################################################
+resource "time_sleep" "delay_between_hub_spoke" {
+  depends_on       = [module.hub_vpc]
+  create_duration  = "30s"
+  destroy_duration = "60s"
+}
+
+#############################################################################
 # Provision VPC
 #############################################################################
 
@@ -55,6 +69,7 @@ data "ibm_iam_account_settings" "iam_account_settings" {}
 
 module "spoke_vpc" {
   source                    = "../../"
+  depends_on                = [time_sleep.delay_between_hub_spoke]
   resource_group_id         = module.resource_group.resource_group_id
   region                    = var.region
   name                      = "spoke"

--- a/examples/hub-spoke-delegated-resolver/version.tf
+++ b/examples/hub-spoke-delegated-resolver/version.tf
@@ -7,5 +7,9 @@ terraform {
       source  = "IBM-Cloud/ibm"
       version = ">= 1.59.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1, < 1.0.0"
+    }
   }
 }


### PR DESCRIPTION
### Description

Placed a delay (via terraform `time_sleep`) in the `hub-spoke-delegated-resolver` example between the Hub module call and the Spoke module call. This delay will help avoid errors when certain resources are not fully complete (either creation or destruction) before the other VPC continues operations.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
