### PR TITLE
fix: hub and spoke example failure in pipeline

### DIFF
--- a/examples/hub-spoke-delegated-resolver/main.tf
+++ b/examples/hub-spoke-delegated-resolver/main.tf
@@ -29,13 +29,14 @@ resource "time_sleep" "delay_between_hub_spoke" {
 #############################################################################
 
 module "hub_vpc" {
-  source            = "../../"
-  resource_group_id = module.resource_group.resource_group_id
-  region            = var.region
-  name              = "hub"
-  prefix            = "${var.prefix}-hub"
-  tags              = var.resource_tags
-  enable_hub        = true
+  source                            = "../../"
+  resource_group_id                 = module.resource_group.resource_group_id
+  region                            = var.region
+  name                              = "hub"
+  prefix                            = "${var.prefix}-hub"
+  tags                              = var.resource_tags
+  enable_hub                        = true
+  skip_custom_resolver_hub_creation = true
   subnets = {
     zone-1 = [
       {


### PR DESCRIPTION
### Description

The continuous test pipeline failed because of the error seen in hub-and-spoke example. This PR intends to resolve the terraform error. 
Included the flag in example, to make sure the example passes.

Refer PR - [#922](https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone-vpc/pull/922)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
