### PR TITLE
fix: Add condition while fetching account ID

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -102,9 +102,23 @@ data "ibm_is_vpc_dns_resolution_bindings" "dns_bindings" {
 # See https://cloud.ibm.com/docs/vpc?topic=vpc-hub-spoke-model for context
 ##############################################################################
 
+locals {
+  create_iam_account_settings = (
+    (
+      var.enable_hub == false &&
+      var.skip_spoke_auth_policy == false &&
+      (var.enable_hub_vpc_id || var.enable_hub_vpc_crn)
+    ) ||
+    (
+      var.enable_vpc_flow_logs &&
+      var.create_authorization_policy_vpc_to_cos
+    )
+  )
+}
+
 # fetch this account ID
 data "ibm_iam_account_settings" "iam_account_settings" {
-  count = (var.enable_hub == false && var.skip_spoke_auth_policy == false && (var.enable_hub_vpc_id || var.enable_hub_vpc_crn)) ? 1 : 0
+  count = local.create_iam_account_settings ? 1 : 0
 }
 
 # spoke -> hub auth policy based on https://cloud.ibm.com/docs/vpc?topic=vpc-vpe-dns-sharing-s2s-auth&interface=terraform

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,9 @@ data "ibm_is_vpc_dns_resolution_bindings" "dns_bindings" {
 ##############################################################################
 
 # fetch this account ID
-data "ibm_iam_account_settings" "iam_account_settings" {}
+data "ibm_iam_account_settings" "iam_account_settings" {
+  count = (var.enable_hub == false && var.skip_spoke_auth_policy == false && (var.enable_hub_vpc_id || var.enable_hub_vpc_crn)) ? 1 : 0
+}
 
 # spoke -> hub auth policy based on https://cloud.ibm.com/docs/vpc?topic=vpc-vpe-dns-sharing-s2s-auth&interface=terraform
 resource "ibm_iam_authorization_policy" "vpc_dns_resolution_auth_policy" {
@@ -112,7 +114,7 @@ resource "ibm_iam_authorization_policy" "vpc_dns_resolution_auth_policy" {
   # subject is the spoke
   subject_attributes {
     name  = "accountId"
-    value = data.ibm_iam_account_settings.iam_account_settings.account_id
+    value = data.ibm_iam_account_settings.iam_account_settings[0].account_id
   }
   subject_attributes {
     name  = "serviceName"
@@ -318,7 +320,7 @@ resource "ibm_iam_authorization_policy" "policy_instance" {
   resource_attributes {
     name     = "accountId"
     operator = "stringEquals"
-    value    = data.ibm_iam_account_settings.iam_account_settings.account_id
+    value    = data.ibm_iam_account_settings.iam_account_settings[0].account_id
   }
 
   resource_attributes {
@@ -351,7 +353,7 @@ resource "ibm_iam_authorization_policy" "policy" {
   resource_attributes {
     name     = "accountId"
     operator = "stringEquals"
-    value    = data.ibm_iam_account_settings.iam_account_settings.account_id
+    value    = data.ibm_iam_account_settings.iam_account_settings[0].account_id
   }
 
   resource_attributes {


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone-vpc/issues/1181

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [X] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Updated the `ibm_iam_account_settings` data source condition to support all IAM authorization policy use cases within the module.

The data block which fetches the account ID is now conditional and will only be called when - 
1. Spoke-to-hub DNS authorization policies are enabled, or
2. VPC Flow Logs authorization policies to COS are enabled.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
